### PR TITLE
Here's one possible realization of a SLAB (Standoff Layered Annotated Blob)

### DIFF
--- a/src/main/scala/chalk/slab/SLAB.scala
+++ b/src/main/scala/chalk/slab/SLAB.scala
@@ -1,0 +1,71 @@
+package chalk.slab
+
+import scala.reflect.ClassTag
+
+trait SLAB[ContentType, BaseAnnotationType, +AnnotationTypes <: BaseAnnotationType] {
+
+  val content: ContentType
+
+  def ++[A <: BaseAnnotationType](annotations: Iterator[A]): SLAB[ContentType, BaseAnnotationType, AnnotationTypes with A]
+
+  def iterator[A >: AnnotationTypes <: BaseAnnotationType: ClassTag]: Iterator[A]
+
+  def covered[A >: AnnotationTypes <: BaseAnnotationType: ClassTag](annotation: BaseAnnotationType): Iterator[A]
+
+  def preceding[A >: AnnotationTypes <: BaseAnnotationType: ClassTag](annotation: BaseAnnotationType): Iterator[A]
+
+  def following[A >: AnnotationTypes <: BaseAnnotationType: ClassTag](annotation: BaseAnnotationType): Iterator[A]
+}
+
+abstract class SLABAnnotationOps[ContentType, BaseAnnotationType, AnnotationType >: AnnotationTypes <: BaseAnnotationType: ClassTag, AnnotationTypes <: BaseAnnotationType](
+  val annotation: AnnotationType,
+  val slab: SLAB[ContentType, BaseAnnotationType, AnnotationTypes]) {
+
+  def content: ContentType
+
+  def covered[A >: AnnotationTypes <: BaseAnnotationType: ClassTag] = this.slab.covered[A](this.annotation)
+
+  def preceding[A >: AnnotationTypes <: BaseAnnotationType: ClassTag] = this.slab.preceding[A](this.annotation)
+
+  def following[A >: AnnotationTypes <: BaseAnnotationType: ClassTag] = this.slab.following[A](this.annotation)
+}
+
+object SLAB {
+  def apply[ContentType, BaseAnnotationType: HasBounds](content: ContentType): SLAB[ContentType, BaseAnnotationType, BaseAnnotationType] =
+    new HorribleInefficientSLAB(content)
+
+  /**
+   * This trait has the minimum necessary for the implementation below.
+   *
+   * An efficient implementation will probably need some other set of operations.
+   */
+  trait HasBounds[AnnotationType] {
+    def covers(annotation1: AnnotationType, annotation2: AnnotationType): Boolean
+    def precedes(annotation1: AnnotationType, annotation2: AnnotationType): Boolean
+    def follows(annotation1: AnnotationType, annotation2: AnnotationType): Boolean
+  }
+
+  private[slab] class HorribleInefficientSLAB[ContentType, BaseAnnotationType, AnnotationTypes <: BaseAnnotationType](
+    val content: ContentType,
+    val _annotations: Seq[Any] = Seq.empty)(
+      implicit hasBounds: HasBounds[BaseAnnotationType])
+    extends SLAB[ContentType, BaseAnnotationType, AnnotationTypes] {
+
+    def ++[AnnotationType](annotations: Iterator[AnnotationType]): SLAB[ContentType, BaseAnnotationType, AnnotationTypes with AnnotationType] =
+      new HorribleInefficientSLAB(this.content, this._annotations ++ annotations)
+
+    def iterator[A >: AnnotationTypes <: BaseAnnotationType: ClassTag]: Iterator[A] =
+      this._annotations.iterator.collect {
+        case annotation: A => annotation
+      }
+
+    def covered[A >: AnnotationTypes <: BaseAnnotationType: ClassTag](annotation: BaseAnnotationType): Iterator[A] =
+      this.iterator[A].filter(a => hasBounds.covers(annotation, a))
+
+    def following[A >: AnnotationTypes <: BaseAnnotationType: ClassTag](annotation: BaseAnnotationType): Iterator[A] =
+      this.iterator[A].filter(a => hasBounds.follows(a, annotation))
+
+    def preceding[A >: AnnotationTypes <: BaseAnnotationType: ClassTag](annotation: BaseAnnotationType): Iterator[A] =
+      this.iterator[A].filter(a => hasBounds.precedes(a, annotation)).toSeq.reverseIterator
+  }
+}

--- a/src/test/scala/chalk/slab/SLABTest.scala
+++ b/src/test/scala/chalk/slab/SLABTest.scala
@@ -1,0 +1,148 @@
+package chalk.slab
+
+import org.scalatest.FunSuite
+import org.scalatest.junit.JUnitRunner
+import org.junit.runner.RunWith
+
+@RunWith(classOf[JUnitRunner])
+class SLABTest extends FunSuite {
+
+  // =========================
+  // Annotation infrastructure
+  // =========================
+  trait StringAnnotation {
+    val begin: Int
+    val end: Int
+    def in[AnnotationTypes <: StringAnnotation](slab: SLAB[String, StringAnnotation, AnnotationTypes]) =
+      new SLABAnnotationOps(this, slab) {
+        def content = this.slab.content.substring(this.annotation.begin, this.annotation.end)
+      }
+  }
+  implicit object StringAnnotationHasBounds extends SLAB.HasBounds[StringAnnotation] {
+    def covers(annotation1: StringAnnotation, annotation2: StringAnnotation): Boolean =
+      annotation1.begin <= annotation2.begin && annotation2.end <= annotation1.end
+    def follows(annotation1: StringAnnotation, annotation2: StringAnnotation): Boolean =
+      annotation2.end <= annotation1.begin
+    def precedes(annotation1: StringAnnotation, annotation2: StringAnnotation): Boolean =
+      annotation1.end <= annotation2.begin
+  }
+
+  // ===========
+  // Annotations
+  // ===========
+  case class Sentence(val begin: Int, val end: Int) extends StringAnnotation
+  case class Token(val begin: Int, val end: Int) extends StringAnnotation
+
+  // =========
+  // Analyzers
+  // =========
+  val stringBegin = (slab: SLAB[String, StringAnnotation, StringAnnotation]) => slab
+
+  def sentenceSegmenter[AnnotationTypes <: StringAnnotation](slab: SLAB[String, StringAnnotation, AnnotationTypes]) =
+    slab ++ "[^\\s.!?]+[^.!?]+[.!?]".r.findAllMatchIn(slab.content).map(m => Sentence(m.start, m.end))
+
+  def tokenizer[AnnotationTypes <: Sentence](slab: SLAB[String, StringAnnotation, AnnotationTypes]) =
+    slab ++ slab.iterator[Sentence].flatMap(sentence =>
+      "\\p{L}+|\\p{P}+|\\p{N}+".r.findAllMatchIn(sentence.in(slab).content).map(m =>
+        Token(sentence.begin + m.start, sentence.begin + m.end)))
+
+  // =========
+  // Tests
+  // =========
+  test("text SLAB") {
+    // should not compile because tokenizer must be after sentence segmenter
+    //val pipeline = begin andThen tokenizer andThen sentenceSegmenter
+
+    // should cause following code (e.g. slab.iterator[Token]) to not compile
+    //val pipeline = begin andThen sentenceSegmenter
+
+    val pipeline = stringBegin andThen sentenceSegmenter andThen tokenizer
+    val slab = pipeline(SLAB("""
+        The skunk thought the stump
+        stunk. The stump thought the
+        skunk stunk.
+        """))
+
+    val sentences = slab.iterator[Sentence].toList
+    assert(sentences.map(_.in(slab).content) === List(
+      """The skunk thought the stump
+        stunk.""",
+      """The stump thought the
+        skunk stunk."""))
+
+    val tokens = slab.iterator[Token].toList
+    assert(tokens.map(_.in(slab).content) === List(
+      "The", "skunk", "thought", "the", "stump", "stunk", ".",
+      "The", "stump", "thought", "the", "skunk", "stunk", "."))
+
+    val sentenceTokens = sentences.map(_.in(slab).covered[Token].toList)
+    assert(sentenceTokens.map(_.map(_.in(slab).content)) === List(
+      List("The", "skunk", "thought", "the", "stump", "stunk", "."),
+      List("The", "stump", "thought", "the", "skunk", "stunk", ".")))
+
+    val tokensBeforeSentence1 = sentences(1).in(slab).preceding[Token].toList
+    assert(tokensBeforeSentence1.map(_.in(slab).content) === List(
+      "The", "skunk", "thought", "the", "stump", "stunk", ".").reverse)
+
+    val sentencesAfterToken5 = tokens(5).in(slab).following[Sentence].toList
+    assert(sentencesAfterToken5.map(_.in(slab).content) === List(
+      """The stump thought the
+        skunk stunk."""))
+  }
+
+  // =====
+  // Image
+  // =====
+  case class Image(val pixelValues: Map[(Int, Int), Int]) {
+    def subimage(pixels: Set[(Int, Int)]): Image = {
+      new Image(this.pixelValues.filter(p => pixels.contains(p._1)))
+    }
+  }
+
+  // =========================
+  // Annotation infrastructure
+  // =========================
+  trait ImageAnnotation {
+    val pixels: Set[(Int, Int)]
+    def in[AnnotationTypes <: ImageAnnotation](slab: SLAB[Image, ImageAnnotation, AnnotationTypes]) =
+      new SLABAnnotationOps(this, slab) {
+        def content = this.slab.content.subimage(this.annotation.pixels)
+      }
+  }
+  implicit object ImageAnnotationHasBounds extends SLAB.HasBounds[ImageAnnotation] {
+    def covers(annotation1: ImageAnnotation, annotation2: ImageAnnotation): Boolean =
+      annotation2.pixels.subsetOf(annotation1.pixels)
+    def follows(annotation1: ImageAnnotation, annotation2: ImageAnnotation): Boolean = ???
+    def precedes(annotation1: ImageAnnotation, annotation2: ImageAnnotation): Boolean = ???
+  }
+
+  // ===========
+  // Annotations
+  // ===========
+  case class Face(val pixels: Set[(Int, Int)]) extends ImageAnnotation
+
+  // =========
+  // Analyzers
+  // =========
+  val imageBegin = (slab: SLAB[Image, ImageAnnotation, ImageAnnotation]) => slab
+
+  def faceRecognizer[AnnotationTypes <: ImageAnnotation](slab: SLAB[Image, ImageAnnotation, AnnotationTypes]) =
+    slab ++ Iterator(Face(Set((0, 0), (0, 1))))
+
+  // =========
+  // Tests
+  // =========
+  test("image SLAB") {
+    val pipeline = imageBegin andThen faceRecognizer
+
+    val image = new Image(Map.empty ++ (for (x <- 0 until 5; y <- 0 until 5) yield ((x, y), 255)))
+    val expectedFaceImage = new Image(Map((0, 0) -> 255, (0, 1) -> 255))
+    val slab = pipeline(SLAB(image))
+
+    val expectedFaceAnnotation = Face(Set((0, 0), (0, 1)))
+    val actualFaces = slab.iterator[Face].toList
+    assert(actualFaces === List(expectedFaceAnnotation))
+    assert(actualFaces.map(_.in(slab).content) === List(expectedFaceImage))
+    assert(actualFaces(0).in(slab).covered[Face].toList === List(expectedFaceAnnotation))
+  }
+}


### PR DESCRIPTION
This is essentially an extended version of what I proposed in https://github.com/bethard/nlp, allowing for SLAB[String, ...] or SLAB[Image, ...], and adding a bit of syntactic sugar for combined SLAB/annotation operations.

To get an idea of how the API is used, the best place to look is in the tests. In particular, `test("text SLAB")` has probably the clearest example. The `test("image SLAB")` is there primarily so that I could get at least a vague idea of what needed to be in the API to support SLABs with content other than Strings. It's not a serious attempt to do image annotation.

The SLAB implementation is horribly inefficient at the moment - as you can tell from the name, HorribleInefficientSLAB ;-) - but I figured we should figure out what API we want before we bother trying to make an efficient implementation. The real implementation probably needs to use interval trees or something like that.
