### PR TITLE
Adds input type parameter to SentenceSegmenter and Tokenizer

### DIFF
--- a/src/main/scala/chalk/slab/AnalysisEngine.scala
+++ b/src/main/scala/chalk/slab/AnalysisEngine.scala
@@ -28,13 +28,13 @@ object AnalysisComponent {
 /**
   * An actor that uses SentenceSegmenter.
   */
-class SentenceSegmenterActor extends SentenceSegmenter
+class SentenceSegmenterActor extends SentenceSegmenter[StringAnnotation]
     with AnalysisComponent[String,StringAnnotation,StringAnnotation,Sentence]
 
 /**
   * An actor that uses Tokenizer.
   */
-class TokenizerActor extends AnalysisComponent[String, StringAnnotation, Sentence, Token] with Tokenizer
+class TokenizerActor extends AnalysisComponent[String, StringAnnotation, Sentence, Token] with Tokenizer[Sentence]
 
 
 /**


### PR DESCRIPTION
Analyzers need to have an input type parameter. Otherwise, you start discarding old annotation types as you move along the pipeline. See the example I added in the main method - if you don't add the type parameters, it's impossible to call `slab.iterator[Document]` after the pipeline is run because the output is just a `Sentence with Token`.

I don't know whether you need the type parameters for the actors approach. Probably not, since that approach relies on .asInstanceOf.
