### PR TITLE
Renames StringAnnotation to Span, adds StringSlab alias

### DIFF
--- a/src/main/scala/chalk/slab/AnalysisEngine.scala
+++ b/src/main/scala/chalk/slab/AnalysisEngine.scala
@@ -52,6 +52,7 @@ class AnalysisEngine extends Actor with ActorLogging {
   import AnalysisComponent._
   import AnalysisEngine._
   import Span._
+  import Slab.StringSlab
   implicit val ec = context.dispatcher
   implicit val timeout = Timeout(10 seconds)
   
@@ -62,8 +63,8 @@ class AnalysisEngine extends Actor with ActorLogging {
     case Process(slab) =>
       log.info("Processing slab:\n " + slab.content)
       (for {
-        slab1 <- (sentenceSegmenter ? Process(slab)).mapTo[Slab[String,Span,Sentence]]
-        slab2 <- (tokenizer ? Process(slab1)).mapTo[Slab[String,Span,Sentence with Token]]
+        slab1 <- (sentenceSegmenter ? Process(slab)).mapTo[StringSlab[Sentence]]
+        slab2 <- (tokenizer ? Process(slab1)).mapTo[StringSlab[Sentence with Token]]
       } yield {
         slab2
       }) pipeTo sender
@@ -82,6 +83,7 @@ object AnalysisEngine {
   
   import AnalysisComponent._
   import Span._
+  import Slab.StringSlab
 
   val text1 = "Here is an example text. It has four sentences and it mentions Jimi Hendrix and Austin, Texas! In this third sentence, it also brings up Led Zeppelin and Radiohead, but does it ask a question? It also has a straggler sentence that doesn't end with punctuation"
 
@@ -99,7 +101,7 @@ object AnalysisEngine {
     val corpus = Iterator(text1,text2,text3)
     
     for {
-      slabs <- (engine ? ProcessCorpus(corpus)).mapTo[Iterator[Slab[String,Span,Sentence with Token]]]
+      slabs <- (engine ? ProcessCorpus(corpus)).mapTo[Iterator[StringSlab[Sentence with Token]]]
       slab <- slabs
     } {
       // Notice that the last sentence (lacking EOS char) is missing.

--- a/src/main/scala/chalk/slab/Slab.scala
+++ b/src/main/scala/chalk/slab/Slab.scala
@@ -45,13 +45,13 @@ trait Span {
 
 object Span {
   implicit class SpanInStringSlab(val span: Span) extends AnyVal {
-    def in[AnnotationTypes <: Span](slab: Slab[String, Span, AnnotationTypes]) =
+    def in[AnnotationTypes <: Span](slab: Slab.StringSlab[AnnotationTypes]) =
       new StringSpanAnnotationOps(this.span, slab)
   }
 
   class StringSpanAnnotationOps[AnnotationType >: AnnotationTypes <: Span: ClassTag, AnnotationTypes <: Span](
     annotation: AnnotationType,
-    slab: Slab[String, Span, AnnotationTypes])
+    slab: Slab.StringSlab[AnnotationTypes])
     extends SlabAnnotationOps[String, Span, AnnotationType, AnnotationTypes](annotation, slab) {
     def content = this.slab.content.substring(this.annotation.begin, this.annotation.end)
   }
@@ -74,6 +74,8 @@ case class Token(val begin: Int, val end: Int) extends Span
 
 
 object Slab {
+  type StringSlab[+AnnotationTypes <: Span] = Slab[String, Span, AnnotationTypes]
+  
   def apply[ContentType, BaseAnnotationType: HasBounds](content: ContentType): Slab[ContentType, BaseAnnotationType, BaseAnnotationType] =
     new HorribleInefficientSlab(content)
 

--- a/src/test/scala/chalk/slab/SlabTest.scala
+++ b/src/test/scala/chalk/slab/SlabTest.scala
@@ -10,12 +10,14 @@ class SlabTest extends FunSuite {
   // =========
   // Analyzers
   // =========
-  val stringBegin = (slab: Slab[String, Span, Span]) => slab
+  import Slab.StringSlab
 
-  def sentenceSegmenter[AnnotationTypes <: Span](slab: Slab[String, Span, AnnotationTypes]) =
+  val stringBegin = (slab: StringSlab[Span]) => slab
+
+  def sentenceSegmenter[AnnotationTypes <: Span](slab: StringSlab[AnnotationTypes]) =
     slab ++ "[^\\s.!?]+[^.!?]+[.!?]".r.findAllMatchIn(slab.content).map(m => Sentence(m.start, m.end))
 
-  def tokenizer[AnnotationTypes <: Sentence](slab: Slab[String, Span, AnnotationTypes]) =
+  def tokenizer[AnnotationTypes <: Sentence](slab: StringSlab[AnnotationTypes]) =
     slab ++ slab.iterator[Sentence].flatMap(sentence =>
       "\\p{L}+|\\p{P}+|\\p{N}+".r.findAllMatchIn(sentence.in(slab).content).map(m =>
         Token(sentence.begin + m.start, sentence.begin + m.end)))


### PR DESCRIPTION
(1) I renamed `StringAnnotation` to `Span`. I know I said we'd have to call it "StringSpan" because "Span" was already tied to Strings by its `in` method, but I figured out a very simple way to move the `in` method out of the `Span` trait, using an implicit value class. So we can just call it "Span" now.

(2) I added a `StringSlab` type alias. Note that it has to be a type alias, not a trait, otherwise the Slab type parameters will get even more complicated to ensure that a StringSlab subclass of Slab always returns StringSlabs, etc. Right now, the type alias is `Slab.StringSlab`, which you would typically import before using. I also considered `Slab.OfString`, with the idea that you wouldn't need to import - you'd just use the fully qualified type. I didn't have a strong opinion though, so I stuck with StringSlab.
